### PR TITLE
fix: fix the reset command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,17 @@ fn main() -> Result<(), Error> {
 
     let config_path = get_config_path().expect("Failed to determine config path");
 
+    if let Some(Commands::Reset) = cli.command {
+        match reset_configuration(config_path.as_path()) {
+            Ok(_) => println!(
+                "Configuration reset to default at {}",
+                config_path.display()
+            ),
+            Err(e) => eprintln!("Failed to reset configuration: {}", e),
+        };
+        return Ok(());
+    }
+
     let config =
         initialize_configuration(cli.config.clone().unwrap_or(config_path.clone()).as_path())?;
 
@@ -106,16 +117,11 @@ fn main() -> Result<(), Error> {
                 }
             }
         },
-        Some(Commands::Reset) => {
-            match reset_configuration(config_path.as_path()) {
-                Ok(_) => println!(
-                    "Configuration reset to default at {}",
-                    config_path.display()
-                ),
-                Err(e) => eprintln!("Failed to reset configuration: {}", e),
-            };
-        }
         None => {
+            let mut cmd = Cli::command();
+            cmd.print_help().ok();
+        }
+        _ => {
             let mut cmd = Cli::command();
             cmd.print_help().ok();
         }


### PR DESCRIPTION
Originally, the reset command will fail if the configuration is failed to be parsed. That defeats the purpose to the command. This pull request fixes the issue.